### PR TITLE
fix: preserve zero quantity when adding item

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,8 +185,8 @@
       tr.innerHTML=`
         <td><input aria-label="Pos" value="${i}" style="width:48px" disabled></td>
         <td><input aria-label="Beschreibung" class="desc" value="${data.desc||''}"></td>
-        <td><input aria-label="Menge" class="qty" type="number" min="0" step="0.01" value="${data.qty||1}"></td>
-        <td><input aria-label="Preis" class="price" type="number" min="0" step="0.01" value="${data.price||0}"></td>
+        <td><input aria-label="Menge" class="qty" type="number" min="0" step="0.01" value="${data.qty ?? 1}"></td>
+        <td><input aria-label="Preis" class="price" type="number" min="0" step="0.01" value="${data.price ?? 0}"></td>
         <td class="t-right subtotal">0,00 €</td>
         <td class="t-right"><button class="btn" title="Entfernen">✕</button></td>`;
       bodyEl.appendChild(tr);


### PR DESCRIPTION
## Summary
- use nullish coalescing to prevent zero quantity from being overwritten

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898fcb6857c8325a2ea1c5f06a664a4