### PR TITLE
feat: improve PDF layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,68 +277,106 @@
 
     // ===== PDF =====
     async function downloadPDF(){
-      try{ await (window.__libsReady||Promise.resolve()); if(typeof PDFLib==='undefined'){ alert('PDF‑Bibliothek nicht geladen.'); return; }
-        const items=getItems(); const vatRate=parseNum(vatEl.value); const sumNet=items.reduce((a,c)=>a+c.qty*c.price,0); const vatAmt=sumNet*vatRate/100; const sumGross=sumNet+vatAmt;
+      try{
+        await (window.__libsReady||Promise.resolve());
+        if(typeof PDFLib==='undefined'){ alert('PDF‑Bibliothek nicht geladen.'); return; }
+        const items=getItems(); const vatRate=parseNum(vatEl.value);
+        const sumNet=items.reduce((a,c)=>a+c.qty*c.price,0); const vatAmt=sumNet*vatRate/100; const sumGross=sumNet+vatAmt;
         const name=document.getElementById('name').value||''; const iban=document.getElementById('iban').value||''; const bic=document.getElementById('bic').value||''; const purpose=document.getElementById('purpose').value||'';
         const senderName=document.getElementById('senderName').value||''; const senderAddress=document.getElementById('senderAddress').value||'';
-        const { PDFDocument, StandardFonts, rgb }=PDFLib; const pdf=await PDFDocument.create(); const page=pdf.addPage([595.28,841.89]); const font=await pdf.embedFont(StandardFonts.Helvetica); const bold=await pdf.embedFont(StandardFonts.HelveticaBold);
-        let logoW=0, logoH=0;
-        const M=50; let y=800;
-        // Header
-        page.drawText('Rechnung', {x:M,y, size:22, font:bold});
-        page.drawText(`Datum: ${new Date().toISOString().slice(0,10)}`, {x:M+360,y, size:10, font}); y-=26;
-        // Absender
-        page.drawText('Absender', {x:M, y, size:10, font:bold, color:rgb(0.7,0.75,0.85)}); y-=14;
-        if(senderName){ page.drawText(senderName, {x:M, y, size:12, font:bold}); y-=14; }
-        if(senderAddress){ senderAddress.split(/\r?\n/).forEach(line=>{ page.drawText(line, {x:M, y, size:11, font}); y-=14; }); }
-        // Zahlungsdaten links
-        page.drawText('Zahlungsdaten', {x:M, y, size:10, font:bold, color:rgb(0.7,0.75,0.85)}); y-=14;
+        const { PDFDocument, StandardFonts, rgb }=PDFLib; const pdf=await PDFDocument.create();
+        const size={w:595.28,h:841.89}; let page=pdf.addPage([size.w,size.h]);
+        const font=await pdf.embedFont(StandardFonts.Helvetica); const bold=await pdf.embedFont(StandardFonts.HelveticaBold);
+        const lineCol=rgb(0.16,0.18,0.25); const muted=rgb(0.45,0.5,0.65);
+        const M=50; let y=size.h-M;
+
+        let logoImg=null, qrImg=null;
+        if(window.__logoBytes){
+          try{ logoImg=window.__logoType==='image/png'?await pdf.embedPng(window.__logoBytes):await pdf.embedJpg(window.__logoBytes); }catch(e){ console.error(e); }
+        }
+        try{
+          const c=document.getElementById('qrCanvas');
+          if(c){ const data=c.toDataURL('image/png'); if(data && data.length>100){ const bytes=await fetch(data).then(r=>r.arrayBuffer()); qrImg=await pdf.embedPng(bytes); } }
+        }catch(_){ }
+
+        function wrap(text,width){
+          const words=String(text||'').split(/\s+/); let line='', out=[];
+          for(const w of words){ const t=line?line+' '+w:w; if(font.widthOfTextAtSize(t,11)>width){ if(line) out.push(line); line=w; } else line=t; }
+          if(line) out.push(line); return out;
+        }
+        function line(){ page.drawLine({start:{x:M,y}, end:{x:size.w-M,y}, thickness:1, color:lineCol}); }
+        function drawHeader(){
+          let top=size.h-M;
+          if(logoImg){
+            const maxW=130,maxH=60; const s=Math.min(maxW/logoImg.width,maxH/logoImg.height,1); const w=logoImg.width*s, h=logoImg.height*s;
+            page.drawImage(logoImg,{x:size.w-M-w,y:top-h,width:w,height:h}); top-=h+10;
+          }
+          y=top;
+          page.drawText('Rechnung',{x:M,y,size:24,font:bold});
+          const ds=new Date().toISOString().slice(0,10); const dw=font.widthOfTextAtSize(ds,10);
+          page.drawText(ds,{x:size.w-M-dw,y:y+8,size:10,font,color:muted});
+          y-=32;
+        }
+        function newPage(){ page=pdf.addPage([size.w,size.h]); drawHeader(); }
+        function addPageIfNeeded(h,after){ if(y-h<M+40){ newPage(); if(after) after(); } }
+        function drawTableHeader(){
+          page.drawText('Pos',{x:cols[0],y,size:11,font:bold,color:muted});
+          page.drawText('Beschreibung',{x:cols[1],y,size:11,font:bold,color:muted});
+          page.drawText('Menge',{x:cols[2],y,size:11,font:bold,color:muted});
+          page.drawText('Preis',{x:cols[3],y,size:11,font:bold,color:muted});
+          page.drawText('Summe',{x:cols[4],y,size:11,font:bold,color:muted});
+          y-=14; line(); y-=14;
+        }
+
+        drawHeader();
+
+        if(senderName || senderAddress){
+          page.drawText('Absender',{x:M,y,size:11,font:bold,color:muted}); y-=14;
+          if(senderName){ page.drawText(senderName,{x:M,y,size:12,font:bold}); y-=14; }
+          if(senderAddress){ senderAddress.split(/\r?\n/).forEach(l=>{ page.drawText(l,{x:M,y,size:11,font}); y-=14; }); }
+          y-=6;
+        }
+
+        const payTop=y;
+        page.drawText('Zahlungsdaten',{x:M,y,size:11,font:bold,color:muted}); y-=14;
         const rows=[["Empfänger",name],["IBAN",iban],["BIC",bic||'-'],["Verwendungszweck",purpose||'-']];
-        const labelW=110; rows.forEach(([k,v])=>{ page.drawText(k+':', {x:M, y, size:11, font, color:rgb(0.45,0.5,0.65)}); page.drawText(String(v), {x:M+labelW, y, size:11, font}); y-=14; });
-        // Logo rechts oben
-        if(window.__logoBytes){ try{ const logoImg = window.__logoType==='image/png'?await pdf.embedPng(window.__logoBytes):await pdf.embedJpg(window.__logoBytes); const maxW=130,maxH=60; const scale=Math.min(maxW/logoImg.width, maxH/logoImg.height,1); logoW=logoImg.width*scale; logoH=logoImg.height*scale; page.drawImage(logoImg,{x:595.28-M-logoW,y:800-logoH/2,width:logoW,height:logoH}); }catch(e){ console.error(e); } }
-        // QR rechts oben
-        try{ const c=document.getElementById('qrCanvas'); if(c){ const data=c.toDataURL('image/png'); if(data && data.length>100){ const bytes=await fetch(data).then(r=>r.arrayBuffer()); const img=await pdf.embedPng(bytes); const q=120; let qrX=595.28-M-q-(logoW?logoW+10:0); page.drawImage(img,{x:qrX,y:800-q/2,width:q,height:q}); } } }catch(_){ }
-        // Linie
-        y-=6; page.drawLine({start:{x:M,y}, end:{x:595.28-M,y}, thickness:1, color:rgb(0.16,0.18,0.25)}); y-=18;
+        const labelW=110; rows.forEach(([k,v])=>{ page.drawText(k+':',{x:M,y,size:11,font,color:muted}); page.drawText(String(v),{x:M+labelW,y,size:11,font}); y-=14; });
+        line(); y-=18;
+        if(qrImg){ const q=110; page.drawImage(qrImg,{x:size.w-M-q,y:payTop-q+10,width:q,height:q}); }
 
-        // Tabelle – Kopf
-        const cols=[M, M+28, M+360, M+430, M+510];
-        page.drawText('Pos', {x:cols[0], y, size:10, font:bold, color:rgb(0.6,0.65,0.75)});
-        page.drawText('Beschreibung', {x:cols[1], y, size:10, font:bold, color:rgb(0.6,0.65,0.75)});
-        page.drawText('Menge', {x:cols[2], y, size:10, font:bold, color:rgb(0.6,0.65,0.75)});
-        page.drawText('Preis', {x:cols[3], y, size:10, font:bold, color:rgb(0.6,0.65,0.75)});
-        page.drawText('Summe', {x:cols[4], y, size:10, font:bold, color:rgb(0.6,0.65,0.75)});
-        y-=10; page.drawLine({start:{x:M,y}, end:{x:595.28-M,y}, thickness:1, color:rgb(0.16,0.18,0.25)}); y-=12;
-
-        // Tabelle – Zeilen (mit Umbruch)
-        const wrap=(text,w)=>{const words=String(text||'').split(/\s+/); let line='', out=[]; for(const w0 of words){ const t=line?line+' '+w0:w0; if(font.widthOfTextAtSize(t,11) > w){ out.push(line); line=w0; } else line=t; } if(line) out.push(line); return out; };
+        const cols=[M,M+30,M+300,M+380,M+460];
+        drawTableHeader();
         items.forEach((it,idx)=>{
-          const sub=it.qty*it.price; const lines=wrap(it.desc, cols[2]-cols[1]-6); const h=lines.length*12; const rowY=y;
-          page.drawText(String(idx+1), {x:cols[0], y:rowY, size:11, font});
-          lines.forEach((ln,i)=>page.drawText(ln,{x:cols[1], y:rowY - i*12, size:11, font}));
-          page.drawText(String(it.qty), {x:cols[2], y:rowY, size:11, font});
-          page.drawText(it.price.toFixed(2)+' €', {x:cols[3], y:rowY, size:11, font});
-          page.drawText(sub.toFixed(2)+' €', {x:cols[4], y:rowY, size:11, font});
-          y -= Math.max(h, 14) + 6;
+          const sub=it.qty*it.price; const lines=wrap(it.desc,cols[2]-cols[1]-8); const h=lines.length*14;
+          addPageIfNeeded(h+20,drawTableHeader);
+          const rowY=y;
+          page.drawText(String(idx+1),{x:cols[0],y:rowY,size:11,font});
+          lines.forEach((ln,i)=>page.drawText(ln,{x:cols[1],y:rowY-i*14,size:11,font}));
+          page.drawText(String(it.qty),{x:cols[2],y:rowY,size:11,font});
+          page.drawText(it.price.toFixed(2)+' €',{x:cols[3],y:rowY,size:11,font});
+          page.drawText(sub.toFixed(2)+' €',{x:cols[4],y:rowY,size:11,font});
+          y-=Math.max(h,14)+6;
         });
 
-        y-=6; page.drawLine({start:{x:M,y}, end:{x:595.28-M,y}, thickness:1, color:rgb(0.16,0.18,0.25)}); y-=12;
+        addPageIfNeeded(100);
+        const boxW=200; const boxH=vatRate?60:40; const boxX=size.w-M-boxW; const boxY=y-boxH;
+        page.drawRectangle({x:boxX,y:boxY,width:boxW,height:boxH,borderColor:lineCol,borderWidth:1});
+        let sy=y-14;
+        if(vatRate){
+          page.drawText('Summe netto',{x:boxX+10,y:sy,size:11,font});
+          page.drawText(sumNet.toFixed(2)+' €',{x:boxX+boxW-10-font.widthOfTextAtSize(sumNet.toFixed(2)+' €',11),y:sy,size:11,font});
+          sy-=14;
+          page.drawText(`USt (${vatRate}%)`,{x:boxX+10,y:sy,size:11,font});
+          page.drawText(vatAmt.toFixed(2)+' €',{x:boxX+boxW-10-font.widthOfTextAtSize(vatAmt.toFixed(2)+' €',11),y:sy,size:11,font});
+          sy-=14;
+        }
+        page.drawText('Gesamt (brutto)',{x:boxX+10,y:sy,size:12,font:bold});
+        page.drawText(sumGross.toFixed(2)+' €',{x:boxX+boxW-10-bold.widthOfTextAtSize(sumGross.toFixed(2)+' €',12),y:sy,size:12,font:bold});
+        y=boxY-30;
 
-        // Summenbox rechts
-        const boxW=220, boxH=56;
-        page.drawRectangle({x:595.28-M-boxW,y:y-boxH+4,width:boxW,height:boxH,borderWidth:1,color:rgb(0.85,0.88,0.95)});
-        page.drawText('Summe netto:', {x:595.28-M-boxW+12, y:y+34, size:10, font});
-        page.drawText(sumNet.toFixed(2)+' €', {x:595.28-M-12, y:y+34, size:10, font});
-        page.drawText(`USt (${vatRate}%) :`, {x:595.28-M-boxW+12, y:y+20, size:10, font});
-        page.drawText(vatAmt.toFixed(2)+' €', {x:595.28-M-12, y:y+20, size:10, font});
-        page.drawText('Gesamt (brutto):', {x:595.28-M-boxW+12, y:y+6, size:11, font:bold});
-        page.drawText(sumGross.toFixed(2)+' €', {x:595.28-M-12, y:y+6, size:11, font:bold});
+        page.drawText('Erstellt lokal im Browser · keine Datenübertragung',{x:M,y:M-20,size:9,font,color:muted});
 
-        // Footer
-        page.drawText('Erstellt lokal im Browser · keine Datenübertragung', {x:M, y:60, size:9, font, color:rgb(0.7,0.75,0.85)});
-
-        const bytes=await pdf.save(); const blob=new Blob([bytes],{type:'application/pdf'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='rechnung.pdf'; a.click(); setTimeout(()=>URL.revokeObjectURL(url), 5000);
+        const bytes=await pdf.save(); const blob=new Blob([bytes],{type:'application/pdf'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='rechnung.pdf'; a.click(); setTimeout(()=>URL.revokeObjectURL(url),5000);
       }catch(e){ console.error(e); alert('PDF‑Fehler: '+(e.message||e)); }
     }
 


### PR DESCRIPTION
## Summary
- refine `downloadPDF` with helper routines for header, wrapping, and page breaks to create a clean A4 invoice layout
- add sender/payment blocks with optional logo and QR code placement
- render item table with wrapped descriptions and summary box

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3163d8a883258567fe8149ff7085