### PR TITLE
fix: ensure canonical knowledge URLs end with trailing slash

### DIFF
--- a/wissen/betrag-und-zweck/index.html
+++ b/wissen/betrag-und-zweck/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Betrag & Verwendungszweck im GiroCode – richtig formatieren</title>
 <meta name="description" content="Betrag & Verwendungszweck korrekt setzen: Format, Best Practices, Beispiele und Fehlervermeidung.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/betrag-und-zweck">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/betrag-und-zweck/">
 <meta name="robots" content="index,follow">
 
 <style>

--- a/wissen/epc-standard/index.html
+++ b/wissen/epc-standard/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis</title>
 <meta name="description" content="EPC‑Standard: Aufbau, Felder, Längen, Formatregeln und Praxistipps für SEPA‑QR (GiroCode).">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/epc-standard">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/epc-standard/">
 <meta name="robots" content="index,follow">
 
 <style>

--- a/wissen/girocode/index.html
+++ b/wissen/girocode/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele</title>
 <meta name="description" content="GiroCode erklärt: SEPA‑QR (EPC), Felder, Vorteile, Praxis, Fehlerbehebung – mit internen Links.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/girocode">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/girocode/">
 <meta name="robots" content="index,follow">
 
 <style>

--- a/wissen/iban-bic/index.html
+++ b/wissen/iban-bic/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden</title>
 <meta name="description" content="IBAN & BIC richtig im GiroCode verwenden: Prüfung, Format, typische Fehler, Praxistipps.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/iban-bic">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/iban-bic/">
 <meta name="robots" content="index,follow">
 
 <style>

--- a/wissen/rechnung/index.html
+++ b/wissen/rechnung/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rechnung mit GiroCode – schneller bezahlt werden</title>
 <meta name="description" content="Rechnung mit GiroCode: Platzierung, Layout, Zuordnung, Best Practices und FAQ.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/rechnung">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/rechnung/">
 <meta name="robots" content="index,follow">
 
 <style>

--- a/wissen/scannen/index.html
+++ b/wissen/scannen/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GiroCode scannen – Anleitung, Probleme lösen, Drucktipps</title>
 <meta name="description" content="GiroCode scannen: Anleitung, Drucktipps und Fehlerlösungen für Banking‑Apps.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/scannen">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/scannen/">
 <meta name="robots" content="index,follow">
 
 <style>


### PR DESCRIPTION
## Summary
- add trailing slash to canonical URLs across Wissen article index pages

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60563698c8325bb01ba027f5fd425