### PR TITLE
Remove trailing slashes from internal URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,12 +184,12 @@
     <details class="dropdown">
       <summary>Wissen</summary>
       <div class="dropdown-panel">
-        <a href="/wissen/girocode/">GiroCode</a>
-        <a href="/wissen/epc-standard/">EPC-Standard</a>
-        <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-        <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-        <a href="/wissen/scannen/">Scannen</a>
-        <a href="/wissen/rechnung/">Rechnung</a>
+        <a href="/wissen/girocode">GiroCode</a>
+        <a href="/wissen/epc-standard">EPC-Standard</a>
+        <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+        <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+        <a href="/wissen/scannen">Scannen</a>
+        <a href="/wissen/rechnung">Rechnung</a>
       </div>
     </details>
     <a href="/impressum">Impressum</a>
@@ -200,15 +200,15 @@
 <section aria-label="Beliebte Themen">
   <h2>Beliebte Themen</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Betrag & Verwendungszweck im GiroCode">
+    <a href="/wissen/betrag-und-zweck" title="Betrag & Verwendungszweck im GiroCode">
       <strong>Betrag &amp; Verwendungszweck</strong>
       <small>Format EUR12.34 & klare Zwecke</small>
     </a>
-    <a href="/wissen/epc-standard/" title="EPC‑Standard">
+    <a href="/wissen/epc-standard" title="EPC‑Standard">
       <strong>EPC‑Standard</strong>
       <small>Aufbau, Felder, Regeln</small>
     </a>
-    <a href="/wissen/rechnung/" title="GiroCode auf Rechnungen">
+    <a href="/wissen/rechnung" title="GiroCode auf Rechnungen">
       <strong>GiroCode auf Rechnungen</strong>
       <small>Platzierung & Zuordnung</small>
     </a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,49 +7,49 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/girocode/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/girocode</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/epc-standard/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/epc-standard</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/iban-bic/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/iban-bic</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/betrag-und-zweck/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/betrag-und-zweck</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/scannen/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/scannen</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/wissen/rechnung/</loc>
+    <loc>https://www.girocodegenerator.com/wissen/rechnung</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/impressum/</loc>
+    <loc>https://www.girocodegenerator.com/impressum</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://www.girocodegenerator.com/datenschutz/</loc>
+    <loc>https://www.girocodegenerator.com/datenschutz</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "redirects": [
-    { "source": "/wissen/:slug", "destination": "/wissen/:slug/", "permanent": true }
+    { "source": "/wissen/:slug/", "destination": "/wissen/:slug", "permanent": true }
   ],
   "cleanUrls": true
 }

--- a/wissen/betrag-und-zweck/index.html
+++ b/wissen/betrag-und-zweck/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Betrag & Verwendungszweck im GiroCode – Format & Beispiele</title>
 <meta name="description" content="Betrag (EUR12.34) und Verwendungszweck im GiroCode korrekt setzen: Beispiele, Best Practices & FAQ.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/betrag-und-zweck/" />
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/betrag-und-zweck" />
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/betrag-und-zweck/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/betrag-und-zweck#faq",
   "mainEntity":[
     {"@type":"Question","name":"Wie formatiere ich den Betrag korrekt?","acceptedAnswer":{"@type":"Answer","text":"Im Format EUR12.34 mit Punkt als Dezimaltrenner und zwei Nachkommastellen."}},
     {"@type":"Question","name":"Wie formuliere ich den Verwendungszweck?","acceptedAnswer":{"@type":"Answer","text":"Kurz, eindeutig, maschinenfreundlich, z. B. RE-2025-0001."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"Betrag & Zweck","item":"https://www.girocodegenerator.com/wissen/betrag-und-zweck/"}
+    {"@type":"ListItem","position":3,"name":"Betrag & Zweck","item":"https://www.girocodegenerator.com/wissen/betrag-und-zweck"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -100,7 +100,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Betrag & Verwendungszweck im GiroCode – richtig formatieren): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10317 -->
@@ -109,8 +109,8 @@
   <h2>Weiterführend</h2>
   <div class="link-grid">
     <a href="/" title="SEPA‑QR Generator"><strong>SEPA‑QR Generator</strong><small>GiroCode jetzt erzeugen</small></a>
-    <a href="/wissen/rechnung/" title="GiroCode auf Rechnung"><strong>GiroCode auf Rechnung</strong><small>Platzierung & Zuordnung</small></a>
-    <a href="/wissen/girocode/" title="GiroCode erklärt"><strong>GiroCode erklärt</strong><small>Nutzen & Beispiele</small></a>
+    <a href="/wissen/rechnung" title="GiroCode auf Rechnung"><strong>GiroCode auf Rechnung</strong><small>Platzierung & Zuordnung</small></a>
+    <a href="/wissen/girocode" title="GiroCode erklärt"><strong>GiroCode erklärt</strong><small>Nutzen & Beispiele</small></a>
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->

--- a/wissen/epc-standard/index.html
+++ b/wissen/epc-standard/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>EPC‑Standard für SEPA‑QR – Felder, Regeln & Praxis</title>
 <meta name="description" content="EPC‑Standard für GiroCode: Aufbau, Felder, Längen, Formatregeln und Praxistipps. So wird der SEPA‑QR zuverlässig erkannt.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/epc-standard/">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/epc-standard">
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/epc-standard/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/epc-standard#faq",
   "mainEntity":[
     {"@type":"Question","name":"Wie ist ein EPC-Datensatz aufgebaut?","acceptedAnswer":{"@type":"Answer","text":"Zeilenbasiert: BCD, Version, Charset, SCT, optional BIC, Name, IBAN, Betrag, zwei optionale Zeilen, Verwendungszweck."}},
     {"@type":"Question","name":"Ist eine BIC erforderlich?","acceptedAnswer":{"@type":"Answer","text":"In vielen SEPA-Fällen nicht. Bei Sonderfällen kann die BIC hilfreich sein."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"EPC-Standard","item":"https://www.girocodegenerator.com/wissen/epc-standard/"}
+    {"@type":"ListItem","position":3,"name":"EPC-Standard","item":"https://www.girocodegenerator.com/wissen/epc-standard"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -103,7 +103,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (EPC‑Standard für SEPA‑QR (GiroCode) – Felder, Formatregeln & Praxis): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10153 -->
@@ -111,14 +111,14 @@
 <section aria-label="Weiterführend">
   <h2>Weiterführend</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Verwendungszweck & Betrag im EPC">
+    <a href="/wissen/betrag-und-zweck" title="Verwendungszweck & Betrag im EPC">
       <strong>Verwendungszweck &amp; Betrag</strong>
       <small>EPC‑konform festlegen</small>
     </a>
-    <a href="/wissen/iban-bic/" title="IBAN & BIC">
+    <a href="/wissen/iban-bic" title="IBAN & BIC">
       <strong>IBAN &amp; BIC</strong><small>Prüfung & Format</small>
     </a>
-    <a href="/wissen/scannen/" title="Scannen">
+    <a href="/wissen/scannen" title="Scannen">
       <strong>GiroCode scannen</strong><small>App‑Tipps & Druckgrößen</small>
     </a>
   </div>

--- a/wissen/girocode/index.html
+++ b/wissen/girocode/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GiroCode erklärt – SEPA‑QR (EPC), Nutzen & Beispiele</title>
 <meta name="description" content="Was ist ein GiroCode? Aufbau, Vorteile, Praxisbeispiele & FAQ. Mit Links zu EPC‑Standard, IBAN/BIC, Betrag & Zweck, Scannen und Rechnung.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/girocode/">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/girocode">
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/girocode/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/girocode#faq",
   "mainEntity":[
     {"@type":"Question","name":"Welche Felder sind im GiroCode Pflicht?","acceptedAnswer":{"@type":"Answer","text":"Pflicht sind Empfängername und IBAN. BIC, Betrag und Verwendungszweck sind optional."}},
     {"@type":"Question","name":"Ist die Erstellung sicher?","acceptedAnswer":{"@type":"Answer","text":"Ja. Die Erzeugung erfolgt lokal im Browser, es werden keine Eingaben an Server übertragen."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"GiroCode","item":"https://www.girocodegenerator.com/wissen/girocode/"}
+    {"@type":"ListItem","position":3,"name":"GiroCode","item":"https://www.girocodegenerator.com/wissen/girocode"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -103,7 +103,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Was ist ein GiroCode? (SEPA‑QR / EPC) – Erklärung, Nutzen & Beispiele): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10492 -->
@@ -111,14 +111,14 @@
 <section aria-label="Weiterführend">
   <h2>Weiterführend</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Betrag & Zweck im SEPA‑QR">
+    <a href="/wissen/betrag-und-zweck" title="Betrag & Zweck im SEPA‑QR">
       <strong>SEPA‑QR: Betrag & Zweck</strong>
       <small>Formatieren & richtig benennen</small>
     </a>
-    <a href="/wissen/epc-standard/" title="EPC‑Standard">
+    <a href="/wissen/epc-standard" title="EPC‑Standard">
       <strong>EPC‑Standard</strong><small>Aufbau & Regeln</small>
     </a>
-    <a href="/wissen/rechnung/" title="Rechnung mit QR">
+    <a href="/wissen/rechnung" title="Rechnung mit QR">
       <strong>Rechnung mit QR</strong><small>Schneller bezahlt werden</small>
     </a>
   </div>

--- a/wissen/iban-bic/index.html
+++ b/wissen/iban-bic/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IBAN & BIC im GiroCode – Prüfung, Format, Fehler</title>
 <meta name="description" content="IBAN & BIC im GiroCode richtig nutzen: Mod‑97‑Prüfung, Format ohne Leerzeichen, typische Fehler und Tipps.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/iban-bic/">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/iban-bic">
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/iban-bic/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/iban-bic#faq",
   "mainEntity":[
     {"@type":"Question","name":"Wie prüfe ich eine IBAN?","acceptedAnswer":{"@type":"Answer","text":"Per Mod-97-Prüfung. Zudem sollten keine Leerzeichen oder unsichtbaren Zeichen enthalten sein."}},
     {"@type":"Question","name":"Wann ist eine BIC sinnvoll?","acceptedAnswer":{"@type":"Answer","text":"Innerhalb des SEPA-Raums oft entbehrlich, aber bei grenzüberschreitenden Zahlungen teils hilfreich."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"IBAN & BIC","item":"https://www.girocodegenerator.com/wissen/iban-bic/"}
+    {"@type":"ListItem","position":3,"name":"IBAN & BIC","item":"https://www.girocodegenerator.com/wissen/iban-bic"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -100,7 +100,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (IBAN & BIC im GiroCode – Prüfung, Format, Fehler vermeiden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10234 -->
@@ -108,13 +108,13 @@
 <section aria-label="Weiterführend">
   <h2>Weiterführend</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Zweck & Betrag">
+    <a href="/wissen/betrag-und-zweck" title="Zweck & Betrag">
       <strong>Zweck &amp; Betrag</strong><small>EUR‑Format & Beispiele</small>
     </a>
-    <a href="/wissen/epc-standard/" title="EPC‑Standard">
+    <a href="/wissen/epc-standard" title="EPC‑Standard">
       <strong>EPC‑Standard</strong><small>Aufbau & Regeln</small>
     </a>
-    <a href="/wissen/rechnung/" title="Rechnung mit QR">
+    <a href="/wissen/rechnung" title="Rechnung mit QR">
       <strong>Rechnung mit QR</strong><small>Platzierung & Zuordnung</small>
     </a>
   </div>

--- a/wissen/rechnung/index.html
+++ b/wissen/rechnung/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rechnung mit GiroCode – schneller bezahlt werden</title>
 <meta name="description" content="GiroCode auf Rechnungen richtig platzieren: Vorteile, Größe, Gestaltung, Zuordnung und FAQ.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/rechnung/">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/rechnung">
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/rechnung/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/rechnung#faq",
   "mainEntity":[
     {"@type":"Question","name":"Wo platziere ich den GiroCode auf der Rechnung?","acceptedAnswer":{"@type":"Answer","text":"Oben rechts oder unten rechts, mit ausreichend Weißraum und hohem Kontrast."}},
     {"@type":"Question","name":"Darf der Betrag fehlen?","acceptedAnswer":{"@type":"Answer","text":"Ja. Viele Apps fragen den Betrag beim Scannen ab, wenn er im QR leer bleibt."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"Rechnung","item":"https://www.girocodegenerator.com/wissen/rechnung/"}
+    {"@type":"ListItem","position":3,"name":"Rechnung","item":"https://www.girocodegenerator.com/wissen/rechnung"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -100,7 +100,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (Rechnung mit GiroCode – schneller bezahlt werden): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10474 -->
@@ -108,13 +108,13 @@
 <section aria-label="Weiterführend">
   <h2>Weiterführend</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Verwendungszweck auf Rechnungen">
+    <a href="/wissen/betrag-und-zweck" title="Verwendungszweck auf Rechnungen">
       <strong>Verwendungszweck auf Rechnungen</strong><small>Klar &amp; maschinenfreundlich</small>
     </a>
-    <a href="/wissen/epc-standard/" title="EPC‑Standard">
+    <a href="/wissen/epc-standard" title="EPC‑Standard">
       <strong>EPC‑Standard</strong><small>Felder & Format</small>
     </a>
-    <a href="/wissen/scannen/" title="Scannen">
+    <a href="/wissen/scannen" title="Scannen">
       <strong>Scannen</strong><small>Größe, Kontrast, Tipps</small>
     </a>
   </div>

--- a/wissen/scannen/index.html
+++ b/wissen/scannen/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GiroCode scannen – Anleitung, Probleme lösen, Drucktipps</title>
 <meta name="description" content="GiroCode scannen in Banking‑Apps: Schritt‑für‑Schritt, häufige Probleme und Druck/Größe‑Empfehlungen.">
-<link rel="canonical" href="https://www.girocodegenerator.com/wissen/scannen/">
+<link rel="canonical" href="https://www.girocodegenerator.com/wissen/scannen">
 <meta name="robots" content="index,follow">
 
 <style>
@@ -33,7 +33,7 @@
 {
   "@context":"https://schema.org",
   "@type":"FAQPage",
-  "@id":"https://www.girocodegenerator.com/wissen/scannen/#faq",
+  "@id":"https://www.girocodegenerator.com/wissen/scannen#faq",
   "mainEntity":[
     {"@type":"Question","name":"Wie scanne ich einen GiroCode in der Banking-App?","acceptedAnswer":{"@type":"Answer","text":"QR-Scanner öffnen, Kamera ruhig halten, Daten prüfen, Zahlung bestätigen."}},
     {"@type":"Question","name":"Was tun, wenn kein Scan möglich ist?","acceptedAnswer":{"@type":"Answer","text":"Größe und Kontrast erhöhen, EPC-Format prüfen, Linse reinigen, Abstand variieren."}},
@@ -48,7 +48,7 @@
   "itemListElement":[
     {"@type":"ListItem","position":1,"name":"Start","item":"https://www.girocodegenerator.com/"},
     {"@type":"ListItem","position":2,"name":"Wissen","item":"https://www.girocodegenerator.com/wissen/"},
-    {"@type":"ListItem","position":3,"name":"Scannen","item":"https://www.girocodegenerator.com/wissen/scannen/"}
+    {"@type":"ListItem","position":3,"name":"Scannen","item":"https://www.girocodegenerator.com/wissen/scannen"}
   ]
 }
 </script>
@@ -56,12 +56,12 @@
 
 <nav class="site-nav" aria-label="Navigation">
   <a href="/">GiroCode Generator</a>
-  <a href="/wissen/girocode/">GiroCode</a>
-  <a href="/wissen/epc-standard/">EPC‑Standard</a>
-  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
-  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
-  <a href="/wissen/scannen/">Scannen</a>
-  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/wissen/girocode">GiroCode</a>
+  <a href="/wissen/epc-standard">EPC‑Standard</a>
+  <a href="/wissen/iban-bic">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen">Scannen</a>
+  <a href="/wissen/rechnung">Rechnung</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
@@ -100,7 +100,7 @@
 <li>Testscan mit 2 Apps</li>
 </ul>
 <h2 id="weiterfuehrend">Weiterführende Inhalte</h2>
-<p><a href="/wissen/epc-standard/">EPC‑Standard</a> · <a href="/wissen/iban-bic/">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck/">Betrag & Zweck</a> · <a href="/wissen/scannen/">Scannen</a> · <a href="/wissen/rechnung/">Rechnung</a> · <a href="/">Start</a></p>
+<p><a href="/wissen/epc-standard">EPC‑Standard</a> · <a href="/wissen/iban-bic">IBAN & BIC</a> · <a href="/wissen/betrag-und-zweck">Betrag & Zweck</a> · <a href="/wissen/scannen">Scannen</a> · <a href="/wissen/rechnung">Rechnung</a> · <a href="/">Start</a></p>
 <a class="cta" href="/">GiroCode jetzt erstellen →</a>
 </div><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Datenschutz</h2><p>Die lokale Verarbeitung ist vorteilhaft. Kommuniziere transparent, dass keine Inhalte auf Servern gespeichert werden, und beachte organisatorische Pflichten.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Praxisbeispiel</h2><p>In diesem Praxisbeispiel zeigen wir Schritt für Schritt, wie du aus realen Daten einen konformen GiroCode erzeugst, ihn in eine Rechnung integrierst und den Scan mit zwei Banking‑Apps testest. Achte auf korrekte Feldlängen, konsistente Beträge und einen robusten Verwendungszweck.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Fehleranalyse</h2><p>Bei Fehlermeldungen arbeite systematisch: IBAN prüfen, Betrag/Format kontrollieren, Kontrast/Größe des QR anpassen. Vergleiche den EPC‑Text mit einem Referenzbeispiel und behebe Abweichungen nacheinander.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Team‑Workflow</h2><p>Definiere Namenskonventionen für Verwendungszwecke, konsistente Nummernkreise und einen kurzen QA‑Prozess. So sinkt die Fehlerquote nachhaltig.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p><h2>Qualitätssicherung</h2><p>Vor dem Rollout: visuelle Kontrolle, Testscan, PDF‑Export, Papierdruck. Ergebnisse protokollieren und Lessons Learned dokumentieren.</p><p>Zusatzhinweis (GiroCode scannen – Anleitung, Probleme lösen, Drucktipps): Nutze interne Verlinkungen auf EPC‑Standard, IBAN & BIC, Betrag & Zweck, Scannen, Rechnung, Start und halte Metadaten konsistent (Title, Description, Canonical). Teste die Lesbarkeit des QR unter unterschiedlichen Lichtbedingungen und auf verschiedenen Displays.</p>
 <!-- body_length_chars:10056 -->
@@ -108,13 +108,13 @@
 <section aria-label="Weiterführend">
   <h2>Weiterführend</h2>
   <div class="link-grid">
-    <a href="/wissen/betrag-und-zweck/" title="Betrag & Zweck festlegen">
+    <a href="/wissen/betrag-und-zweck" title="Betrag & Zweck festlegen">
       <strong>Betrag &amp; Zweck festlegen</strong><small>Für fehlerfreie Zuordnung</small>
     </a>
-    <a href="/wissen/girocode/" title="GiroCode erklärt">
+    <a href="/wissen/girocode" title="GiroCode erklärt">
       <strong>GiroCode erklärt</strong><small>Nutzen & Beispiele</small>
     </a>
-    <a href="/wissen/rechnung/" title="Rechnung mit QR">
+    <a href="/wissen/rechnung" title="Rechnung mit QR">
       <strong>Rechnung mit QR</strong><small>Best Practices</small>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- normalize internal sitemap and canonical URLs to omit trailing slashes
- update navigation links and add redirect for slug paths without trailing slash

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/girocode-pdf/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a7298ea49c8325aba0f4f40676ae2a