### PR TITLE
Add synonym sections and FAQs

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,12 @@
     .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
     .link-grid a:hover{opacity:1;transform:translateY(-1px)}
     .link-grid small{display:block;opacity:.75;margin-top:4px}
+    .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+    [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+    .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+    .intent-syn p{margin:0 0 6px;opacity:.95}
+    .intent-syn ul{margin:8px 0 0 1.2em}
+    .intent-syn li{margin:.15rem 0}
   </style>
   <style>
 /* ——— Top-Nav (gekapselt, überschreibt nichts Globales) ——— */
@@ -196,6 +202,19 @@
     <a href="/datenschutz">Datenschutz</a>
   </nav>
 </header>
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Auch gesucht als</h2>
+  <p>Viele Nutzer suchen nach denselben Funktionen unter anderen Begriffen. Unser Tool deckt alle Varianten ab:</p>
+  <ul>
+    <li>SEPA‑QR Code Generator</li>
+    <li>EPC QR Code / EPC‑Standard QR</li>
+    <li>Überweisungs‑QR / Zahlungs‑QR</li>
+    <li>GiroCode für Rechnung / QR‑Rechnung</li>
+    <li>QR‑Überweisung (SEPA)</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
 <!-- INTERNAL-LINKS:START -->
 <section aria-label="Beliebte Themen">
   <h2>Beliebte Themen</h2>

--- a/wissen/betrag-und-zweck/index.html
+++ b/wissen/betrag-und-zweck/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -114,4 +120,17 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>Neben „GiroCode“ sind auch SEPA‑QR, EPC‑QR oder Überweisungs‑QR gebräuchlich, wenn es um Betrag & Zweck im Zahlungs‑QR geht.</p>
+  <ul>
+    <li>SEPA‑QR / GiroCode</li>
+    <li>EPC QR Code</li>
+    <li>Überweisungs‑QR / Zahlungs‑QR</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Kann der Betrag im „Überweisungs‑QR“ leer bleiben?</summary><p>Ja. Viele Apps fragen den Betrag beim Scannen ab, wenn er im QR nicht hinterlegt ist.</p></details>
+<details><summary>Ist „QR‑Rechnung“ dasselbe wie „GiroCode auf Rechnung“?</summary><p>Im Alltag ja: Gemeint ist eine Rechnung mit SEPA‑QR (GiroCode) für die Überweisung.</p></details>
 </main></body></html>

--- a/wissen/epc-standard/index.html
+++ b/wissen/epc-standard/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -124,4 +130,17 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>Der EPC‑Standard ist die technische Basis für SEPA‑QR, GiroCode und Überweisungs‑QR.</p>
+  <ul>
+    <li>EPC QR Code</li>
+    <li>SEPA‑QR / GiroCode</li>
+    <li>Überweisungs‑QR (SEPA)</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Heißt „EPC‑QR“ dasselbe wie „SEPA‑QR“?</summary><p>Ja. EPC beschreibt den Standard; SEPA‑QR bzw. GiroCode ist die praktische Bezeichnung in Apps.</p></details>
+<details><summary>Welche Begriffe verwenden Banken?</summary><p>Üblich sind „GiroCode“, „SEPA‑QR“, „EPC‑QR“ oder „Überweisungs‑QR“. Alle beziehen sich auf denselben QR‑Zahlungsstandard.</p></details>
 </main></body></html>

--- a/wissen/girocode/index.html
+++ b/wissen/girocode/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -124,4 +130,18 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>„GiroCode“ wird häufig auch als SEPA‑QR oder EPC‑QR bezeichnet. Gemeint ist derselbe standardisierte Zahlungs‑QR.</p>
+  <ul>
+    <li>SEPA‑QR Code (GiroCode)</li>
+    <li>EPC QR Code / EPC‑Standard QR</li>
+    <li>Überweisungs‑QR / Zahlungs‑QR</li>
+    <li>QR‑Überweisung</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Ist GiroCode dasselbe wie SEPA‑QR / EPC‑QR?</summary><p>Ja. „GiroCode“, „SEPA‑QR“ und „EPC‑QR“ bezeichnen denselben standardisierten QR‑Code für SEPA‑Überweisungen nach EPC‑Spezifikation.</p></details>
+<details><summary>Kann ich den GiroCode als „Überweisungs‑QR“ nutzen?</summary><p>Ja. Viele Banking‑Apps nennen die Funktion „Überweisungs‑QR“. Unser Generator erzeugt kompatible Codes für diese Scanner.</p></details>
 </main></body></html>

--- a/wissen/iban-bic/index.html
+++ b/wissen/iban-bic/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -120,4 +126,17 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>Bei IBAN/BIC im QR sprechen Nutzer oft von SEPA‑QR, GiroCode oder Überweisungs‑QR.</p>
+  <ul>
+    <li>GiroCode / SEPA‑QR</li>
+    <li>EPC‑QR Code</li>
+    <li>Überweisungs‑QR</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Unterscheidet sich IBAN im GiroCode von SEPA‑QR?</summary><p>Nein. Es ist derselbe Datensatz: IBAN blockfrei, optional BIC.</p></details>
+<details><summary>Akzeptieren Apps „Überweisungs‑QR“ mit BIC?</summary><p>Ja, sofern der Scanner den EPC‑Standard unterstützt. BIC ist optional.</p></details>
 </main></body></html>

--- a/wissen/rechnung/index.html
+++ b/wissen/rechnung/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -120,4 +126,17 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>Für Rechnungen liest man auch „QR‑Rechnung“, „GiroCode auf Rechnung“ oder „Überweisungs‑QR auf Rechnung“.</p>
+  <ul>
+    <li>QR‑Rechnung (SEPA‑QR)</li>
+    <li>GiroCode auf Rechnung</li>
+    <li>Überweisungs‑QR</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Unterschied „QR‑Rechnung“ und „GiroCode auf Rechnung“?</summary><p>Beides beschreibt eine Rechnung mit SEPA‑QR (GiroCode). Die Datenstruktur ist identisch.</p></details>
+<details><summary>Kann ich „Zahlungs‑QR“ schreiben?</summary><p>Ja. Das ist eine übliche Bezeichnung für den gleichen EPC‑konformen GiroCode.</p></details>
 </main></body></html>

--- a/wissen/scannen/index.html
+++ b/wissen/scannen/index.html
@@ -27,6 +27,12 @@
   .link-grid a{display:block;padding:10px 12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;text-decoration:none;opacity:.95}
   .link-grid a:hover{opacity:1;transform:translateY(-1px)}
   .link-grid small{display:block;opacity:.75;margin-top:4px}
+  .intent-syn{margin:16px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .intent-syn{background:rgba(0,0,0,.03)}
+  .intent-syn h2{margin:0 0 8px;font-size:1.05rem}
+  .intent-syn p{margin:0 0 6px;opacity:.95}
+  .intent-syn ul{margin:8px 0 0 1.2em}
+  .intent-syn li{margin:.15rem 0}
 </style>
 
 <script type="application/ld+json">
@@ -120,4 +126,17 @@
   </div>
 </section>
 <!-- INTERNAL-LINKS:END -->
+<!-- INTENT-SYNONYMS:START -->
+<section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
+  <h2>Synonyme & Suchbegriffe</h2>
+  <p>Scanner in Apps heißen oft „SEPA‑QR“, „GiroCode“ oder „Überweisungs‑QR“.</p>
+  <ul>
+    <li>SEPA‑QR / GiroCode scannen</li>
+    <li>EPC‑QR</li>
+    <li>Überweisungs‑QR</li>
+  </ul>
+</section>
+<!-- INTENT-SYNONYMS:END -->
+<details><summary>Meine App nennt es „Überweisungs‑QR“. Funktioniert der Code?</summary><p>Ja. Wenn die App EPC‑SEPA‑QR unterstützt, wird der GiroCode korrekt erkannt.</p></details>
+<details><summary>Ist „EPC‑QR“ kompatibel zum „GiroCode“?</summary><p>Ja, es ist derselbe Standard. Unterschiede bestehen nur in der Bezeichnung.</p></details>
 </main></body></html>


### PR DESCRIPTION
## Summary
- add reusable .intent-syn styles across pages
- insert synonym search blocks on homepage and knowledge pages
- expand FAQs with QR terminology clarifications

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7695824648325ad47533936af4d49