### PR TITLE
Add author metadata and trust elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,14 @@
     .intent-syn p{margin:0 0 6px;opacity:.95}
     .intent-syn ul{margin:8px 0 0 1.2em}
     .intent-syn li{margin:.15rem 0}
+    .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+    [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+    .author-box .meta{font-size:.95rem;opacity:.95}
+    .author-box .meta .muted{opacity:.75}
+    .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+    .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+    [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+    .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
   </style>
   <style>
 /* ——— Top-Nav (gekapselt, überschreibt nichts Globales) ——— */
@@ -198,10 +206,20 @@
         <a href="/wissen/rechnung">Rechnung</a>
       </div>
     </details>
+    <a href="/ueber-uns/">Über uns</a>
     <a href="/impressum">Impressum</a>
     <a href="/datenschutz">Datenschutz</a>
   </nav>
 </header>
+<!-- TRUST-BAR:START -->
+<nav class="breadcrumbs" aria-label="Brotkrumen"><a href="/">Start</a> › <span>GiroCode Generator</span></nav>
+<section aria-label="Sicherheit & Vertrauen" class="trust-bar">
+  <div class="badge"><strong>100% lokal</strong><br><span class="muted">Keine Server‑Speicherung deiner Eingaben</span></div>
+  <div class="badge"><strong>EPC/SEPA‑konform</strong><br><span class="muted">Kompatibel mit gängigen Banking‑Apps</span></div>
+  <div class="badge"><strong>Transparenz</strong><br><span class="muted"><a href="/impressum/">Impressum</a> &nbsp;·&nbsp; <a href="/datenschutz/">DSGVO‑Hinweise</a></span></div>
+  <div class="badge"><strong>Stand</strong><br><span class="muted"><time datetime="2025-08-21">Aktualisiert 21.08.2025</time></span></div>
+</section>
+<!-- TRUST-BAR:END -->
 <!-- INTENT-SYNONYMS:START -->
 <section class="intent-syn" aria-label="Synonyme & Suchbegriffe">
   <h2>Auch gesucht als</h2>

--- a/ueber-uns/index.html
+++ b/ueber-uns/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><html lang="de"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Über uns – GiroCodeGenerator.com</title>
+<meta name="description" content="Wer hinter dem GiroCode Generator steht: Ziel, Qualität, Transparenz, Kontakt und rechtliche Informationen.">
+<meta name="robots" content="index,follow">
+<style>
+  body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:0;background:#0b0c10;color:#e8eaf0}
+  .wrap{max-width:980px;margin:0 auto;padding:28px}
+  a{color:#86efac} h1{margin:0 0 12px}
+  .card{background:#121318;border:1px solid #1f2431;border-radius:14px;padding:18px;margin:12px 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
+</style>
+</head><body><main class="wrap">
+<nav class="site-nav" aria-label="Navigation">
+  <a href="/">GiroCode Generator</a>
+  <a href="/wissen/girocode/">GiroCode</a>
+  <a href="/wissen/epc-standard/">EPC‑Standard</a>
+  <a href="/wissen/iban-bic/">IBAN &amp; BIC</a>
+  <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
+  <a href="/wissen/scannen/">Scannen</a>
+  <a href="/wissen/rechnung/">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
+  <a href="/impressum/">Impressum</a>
+  <a href="/datenschutz/">Datenschutz</a>
+</nav>
+<h1>Über uns</h1>
+<section class="card">
+  <p><strong>GiroCodeGenerator.com</strong> hilft dir, SEPA‑QR‑Codes (GiroCode/EPC) schnell, sicher und lokal im Browser zu erstellen – inklusive Rechnungs‑PDF.</p>
+  <p><strong>Vertrauen & Transparenz:</strong> Keine Server‑Speicherung deiner Inhalte. Der Code läuft vollständig client‑seitig. Hinweise zur Datenverarbeitung findest du in unserer <a href="/datenschutz/">Datenschutzerklärung</a>.</p>
+  <p><strong>Verantwortlich (Anbieter):</strong><br>Kaleb Jahnke, Koppelstraße 6a, 27711 Osterholz‑Scharmbeck – siehe <a href="/impressum/">Impressum</a>.</p>
+  <p><strong>Qualitätsgrundsätze:</strong> Einhaltung des EPC‑Standards, Testscans mit gängigen Banking‑Apps, klare Dokumentation und regelmäßige Aktualisierung (<time datetime="2025-08-21">Stand 21.08.2025</time>).</p>
+  <p><strong>Kontakt:</strong> Für Fragen/Feedback nutze bitte die Angaben im <a href="/impressum/">Impressum</a>.</p>
+</section>
+</main></body></html>

--- a/wissen/betrag-und-zweck/index.html
+++ b/wissen/betrag-und-zweck/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Betrag & Verwendungszweck im GiroCode – Format & Beispiele</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="Betrag (EUR12.34) und Verwendungszweck im GiroCode korrekt setzen: Beispiele, Best Practices & FAQ.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/betrag-und-zweck" />
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>Betrag & Verwendungszweck im GiroCode</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#betrag-formatieren">Betrag formatieren</a> · <a href="#verwendungszweck-formulieren">Verwendungszweck formulieren</a> · <a href="#best-practices--beispiele">Best Practices & Beispiele</a> · <a href="#fehler-vermeiden">Fehler vermeiden</a></div>
 <p>Betrag und Verwendungszweck steuern, wie gut Zahlungen zugeordnet werden können. Ein sauber gesetzter Zweck reduziert manuelle Klärungen.</p>

--- a/wissen/epc-standard/index.html
+++ b/wissen/epc-standard/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>EPC‑Standard für SEPA‑QR – Felder, Regeln & Praxis</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="EPC‑Standard für GiroCode: Aufbau, Felder, Längen, Formatregeln und Praxistipps. So wird der SEPA‑QR zuverlässig erkannt.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/epc-standard">
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>EPC‑Standard für SEPA‑QR (GiroCode)</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#aufbau">Aufbau</a> · <a href="#felder--lngen">Felder & Längen</a> · <a href="#formatregeln">Formatregeln</a> · <a href="#praxistipps">Praxis‑Tipps</a> · <a href="#validierung--tests">Validierung & Tests</a></div>
 <p>Der <strong>EPC‑Standard</strong> (European Payments Council) legt fest, wie SEPA‑QR‑Codes strukturiert sind, damit Banking‑Apps sie zuverlässig interpretieren.</p>

--- a/wissen/girocode/index.html
+++ b/wissen/girocode/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GiroCode erklärt – SEPA‑QR (EPC), Nutzen & Beispiele</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="Was ist ein GiroCode? Aufbau, Vorteile, Praxisbeispiele & FAQ. Mit Links zu EPC‑Standard, IBAN/BIC, Betrag & Zweck, Scannen und Rechnung.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/girocode">
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>Was ist ein GiroCode? (SEPA‑QR / EPC)</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#grundlagen--nutzen">Grundlagen & Nutzen</a> · <a href="#inhalt-des-codes">Inhalt des Codes</a> · <a href="#schrittfrschritt">Schritt‑für‑Schritt</a> · <a href="#best-practices">Best Practices</a> · <a href="#hufige-fehler">Häufige Fehler</a></div>
 <p>Ein <strong>GiroCode</strong> ist ein standardisierter <strong>SEPA‑QR‑Code</strong> (EPC), der Zahlungsdaten maschinenlesbar macht. Durch das Scannen in einer Banking‑App werden Felder automatisch gefüllt – schnell, sicher und fehlerarm.</p>

--- a/wissen/iban-bic/index.html
+++ b/wissen/iban-bic/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IBAN & BIC im GiroCode – Prüfung, Format, Fehler</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="IBAN & BIC im GiroCode richtig nutzen: Mod‑97‑Prüfung, Format ohne Leerzeichen, typische Fehler und Tipps.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/iban-bic">
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>IBAN & BIC im GiroCode</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#iban-prfen">IBAN prüfen</a> · <a href="#bic--optional-aber-ntzlich">BIC – optional, aber nützlich</a> · <a href="#hufige-fehler">Häufige Fehler</a> · <a href="#praxis">Praxis</a></div>
 <p>Die <strong>IBAN</strong> ist Pflicht im GiroCode; sie muss ohne Leerzeichen kodiert sein. Die <strong>BIC</strong> ist optional, aber in manchen Fällen nützlich.</p>

--- a/wissen/rechnung/index.html
+++ b/wissen/rechnung/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rechnung mit GiroCode – schneller bezahlt werden</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="GiroCode auf Rechnungen richtig platzieren: Vorteile, Größe, Gestaltung, Zuordnung und FAQ.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/rechnung">
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>Rechnung mit GiroCode</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#vorteile">Vorteile</a> · <a href="#platzierung--layout">Platzierung & Layout</a> · <a href="#prozess--zuordnung">Prozess & Zuordnung</a> · <a href="#best-practices">Best Practices</a></div>
 <p>Ein GiroCode auf der Rechnung beschleunigt Zahlungseingänge und reduziert Rückfragen. Die korrekte Platzierung verhindert Überlappungen.</p>

--- a/wissen/scannen/index.html
+++ b/wissen/scannen/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="de"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>GiroCode scannen – Anleitung, Probleme lösen, Drucktipps</title>
+<meta name="author" content="Kaleb Jahnke">
 <meta name="description" content="GiroCode scannen in Banking‑Apps: Schritt‑für‑Schritt, häufige Probleme und Druck/Größe‑Empfehlungen.">
 <link rel="canonical" href="https://www.girocodegenerator.com/wissen/scannen">
 <meta name="robots" content="index,follow">
@@ -33,6 +34,14 @@
   .intent-syn p{margin:0 0 6px;opacity:.95}
   .intent-syn ul{margin:8px 0 0 1.2em}
   .intent-syn li{margin:.15rem 0}
+  .author-box{display:flex;gap:12px;align-items:center;margin:12px 0;padding:12px;border:1px solid rgba(125,125,125,.18);border-radius:12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .author-box{background:rgba(0,0,0,.03)}
+  .author-box .meta{font-size:.95rem;opacity:.95}
+  .author-box .meta .muted{opacity:.75}
+  .trust-bar{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:14px 0}
+  .trust-bar .badge{border:1px solid rgba(125,125,125,.18);border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.04)}
+  [data-theme="light"] .trust-bar .badge{background:rgba(0,0,0,.03)}
+  .breadcrumbs{font-size:.9rem;opacity:.85;margin:8px 0}
 </style>
 
 <script type="application/ld+json">
@@ -68,11 +77,21 @@
   <a href="/wissen/betrag-und-zweck">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
+  <a href="/ueber-uns/">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>
 
 <h1>GiroCode scannen</h1>
+<!-- AUTHOR-BOX:START -->
+<section class="author-box" aria-label="Autor & Aktualisierung">
+  <div class="meta">
+    <strong>Autor:</strong> Kaleb Jahnke<br>
+    <span class="muted">Letzte Aktualisierung: <time datetime="2025-08-21">21.08.2025</time></span><br>
+    <a href="/impressum/">Impressum</a> · <a href="/datenschutz/">Datenschutz</a>
+  </div>
+</section>
+<!-- AUTHOR-BOX:END -->
 <div class="card">
 <div class="toc"><strong>Inhalt:</strong> <a href="#anleitung">Anleitung</a> · <a href="#probleme--lsungen">Probleme & Lösungen</a> · <a href="#drucktipps">Drucktipps</a> · <a href="#praxisflle">Praxisfälle</a></div>
 <p>Viele Banking‑Apps unterstützen das Scannen von GiroCodes. Sauberer Druck und richtige Größe sind der Schlüssel zur zuverlässigen Erkennung.</p>


### PR DESCRIPTION
## Summary
- add shared E-E-A-T styles
- include author meta tags and author boxes on knowledge pages
- insert trust bar and about link across navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7755c524c8325afc4453591ff1495