### PR TITLE
chore: update sitemap and robots for indexing

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow:
+
 Sitemap: https://www.girocodegenerator.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,63 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Previous sitemap replaced on 2025-08-23; see git history for prior versions. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.girocodegenerator.com/</loc>
     <lastmod>2025-08-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/girocode</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/epc-standard</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/iban-bic</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/betrag-und-zweck</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/scannen</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/wissen/rechnung</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/impressum</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://www.girocodegenerator.com/ueber-uns</loc>
-    <lastmod>2025-08-23</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.girocodegenerator.com/datenschutz</loc>
     <lastmod>2025-08-23</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/impressum</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/ueber-uns</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/banking-apps</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/betrag-und-zweck</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/epc-standard</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/girocode</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/iban-bic</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/rechnung</loc>
+    <lastmod>2025-08-23</lastmod>
+  </url>
+  <url>
+    <loc>https://www.girocodegenerator.com/wissen/scannen</loc>
+    <lastmod>2025-08-23</lastmod>
   </url>
 </urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,15 @@
     },
     { "source": "/wissen/:slug/", "destination": "/wissen/:slug", "permanent": true }
   ],
+  "headers": [
+    {
+      "source": "/sitemap.xml",
+      "headers": [{ "key": "Content-Type", "value": "application/xml; charset=utf-8" }]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [{ "key": "Content-Type", "value": "text/plain; charset=utf-8" }]
+    }
+  ],
   "cleanUrls": true
 }


### PR DESCRIPTION
## Summary
- clean up robots.txt and add header rules for crawl files
- rebuild sitemap.xml with canonical URLs and last modified dates
- include banking apps article in sitemap

## Testing
- `xmllint --noout sitemap.xml` *(fails: command not found, apt repository 403)*
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('sitemap.xml')
print('XML valid')
PY`
- `curl -I https://www.girocodegenerator.com/sitemap.xml` *(fails: HTTP 403 from proxy)*
- `curl -I https://www.girocodegenerator.com/robots.txt` *(fails: HTTP 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d38b6070832584aa1e245639dc45