### PR TITLE
Normalize ueber-uns URL usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
         <a href="/wissen/banking-apps">Banking‑Apps</a>
       </div>
     </details>
-    <a href="/ueber-uns/">Über uns</a>
+    <a href="/ueber-uns">Über uns</a>
     <a href="/impressum">Impressum</a>
     <a href="/datenschutz">Datenschutz</a>
   </nav>

--- a/ueber-uns/index.html
+++ b/ueber-uns/index.html
@@ -36,7 +36,7 @@
   <a href="/wissen/betrag-und-zweck/">Betrag &amp; Zweck</a>
   <a href="/wissen/scannen/">Scannen</a>
   <a href="/wissen/rechnung/">Rechnung</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum/">Impressum</a>
   <a href="/datenschutz/">Datenschutz</a>
 </nav>

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,8 @@
       "destination": "https://www.girocodegenerator.com/:path*",
       "permanent": true
     },
-    { "source": "/wissen/:slug/", "destination": "/wissen/:slug", "permanent": true }
+    { "source": "/wissen/:slug/", "destination": "/wissen/:slug", "permanent": true },
+    { "source": "/ueber-uns/", "destination": "/ueber-uns", "permanent": true }
   ],
   "headers": [
     {

--- a/wissen/betrag-und-zweck/index.html
+++ b/wissen/betrag-und-zweck/index.html
@@ -78,7 +78,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>

--- a/wissen/epc-standard/index.html
+++ b/wissen/epc-standard/index.html
@@ -78,7 +78,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>

--- a/wissen/girocode/index.html
+++ b/wissen/girocode/index.html
@@ -95,7 +95,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>

--- a/wissen/iban-bic/index.html
+++ b/wissen/iban-bic/index.html
@@ -78,7 +78,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>

--- a/wissen/rechnung/index.html
+++ b/wissen/rechnung/index.html
@@ -78,7 +78,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>

--- a/wissen/scannen/index.html
+++ b/wissen/scannen/index.html
@@ -78,7 +78,7 @@
   <a href="/wissen/scannen">Scannen</a>
   <a href="/wissen/rechnung">Rechnung</a>
   <a href="/wissen/banking-apps">Banking‑Apps</a>
-  <a href="/ueber-uns/">Über uns</a>
+  <a href="/ueber-uns">Über uns</a>
   <a href="/impressum">Impressum</a>
   <a href="/datenschutz">Datenschutz</a>
 </nav>


### PR DESCRIPTION
## Summary
- redirect `/ueber-uns/` to `/ueber-uns`
- use `/ueber-uns` (no trailing slash) in navigation links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaef5103308325b48bde2005c921eb